### PR TITLE
return http.server from application.listen

### DIFF
--- a/lib/framework/application.js
+++ b/lib/framework/application.js
@@ -225,7 +225,7 @@ app.listen = function () {
 	 * STEP 8 : Start server
 	 * Start server
 	 */
-	_listen.apply(this, arguments);
+	return _listen.apply(this, arguments);
 };
 
 


### PR DESCRIPTION
Return the server instance from application listen function.
This allows:
* Gracefull shutdown, by allowing the consumer to call `server.close` when required.
* Integration testing of contentstack-express.

More info:
https://nodejs.org/api/net.html#net_server_listen
http://expressjs.com/en/api.html#app.listen